### PR TITLE
Re-implement insert statements with correct types

### DIFF
--- a/dev/src/schedule.rs
+++ b/dev/src/schedule.rs
@@ -8,7 +8,7 @@ use crate::scrape::{filename, get_to_file};
 use crate::sql::connect;
 use crate::void::{OptionExt, ResultExt};
 use rayon::prelude::*;
-use rusqlite::{Connection, NO_PARAMS};
+use rusqlite::{Connection, ToSql, NO_PARAMS};
 use serde::Deserialize;
 use serde_json::Number;
 use std::env::var;
@@ -146,15 +146,15 @@ fn insert(schedule: Schedule, c: &mut Connection) {
             for date in schedule.dates {
                 for game in date.games {
                     p.execute(&[
-                        &game.gamePk.to_string(),
+                        &game.gamePk.to_string() as &ToSql,
                         &game.status.abstractGameState,
                         &game.status.detailedState,
-                        &game.status.startTimeTBD.to_string(),
+                        &game.status.startTimeTBD,
                         &date.date,
                         &game.gameType,
                         &game.season,
-                        &game.teams.home.team.id.to_string(),
-                        &game.teams.away.team.id.to_string(),
+                        &game.teams.home.team.id,
+                        &game.teams.away.team.id,
                         &game.venue.name,
                     ])
                     .void()

--- a/dev/src/teams.rs
+++ b/dev/src/teams.rs
@@ -5,7 +5,7 @@ mod void;
 use crate::blobs::read_json;
 use crate::sql::connect;
 use crate::void::ResultExt;
-use rusqlite::{Connection, NO_PARAMS};
+use rusqlite::{Connection, ToSql, NO_PARAMS};
 use serde::Deserialize;
 use std::env::var;
 use std::path::Path;
@@ -52,7 +52,7 @@ fn insert(c: &mut Connection, teams: &[Team]) {
         if let Ok(mut p) = t.prepare(INSERT_TEAMS) {
             for team in teams {
                 p.execute(&[
-                    &team.id.to_string(),
+                    &team.id as &ToSql,
                     &team.abbreviation,
                     &team.name,
                     &team.venue.name,


### PR DESCRIPTION
When upgrading Rusqlite, got an error complaining about types on the insert statement arrays... so I convered everything to String and moved on. This resulted in some weird behavior in the database, but Sqlite didn't seem to complain about the odd inserts. So there's that. :shrug: This commit is mostly because my brain is bad though.